### PR TITLE
fix video crashing on Android because of unresolved ExoPlayer breaking changes

### DIFF
--- a/android/sharedCode/src/main/java/com/viro/core/internal/AVPlayer.java
+++ b/android/sharedCode/src/main/java/com/viro/core/internal/AVPlayer.java
@@ -145,6 +145,10 @@ public class AVPlayer {
     }
 
     private <T> T runSynchronouslyOnMainThread(PlayerAction<T> action) throws ExecutionException, InterruptedException {
+        if (Looper.myLooper() == Looper.getMainLooper()) {
+            return action.performAction(mExoPlayer);
+        }
+
         Callable<T> callable = () -> action.performAction(mExoPlayer);
         FutureTask<T> future = new FutureTask<>(callable);
 


### PR DESCRIPTION
This fixes video crashing on Android because of unresolved ExoPlayer breaking changes (mainly because of the new threading model https://developer.android.com/reference/androidx/media3/exoplayer/ExoPlayer#threading-model) 
https://github.com/NativeVision/viro/issues/229