### PR TITLE
Fix Android video recording: color pipeline + RVCCA build guard

### DIFF
--- a/android/sharedCode/src/main/cpp/VROAVRecorderAndroid.cpp
+++ b/android/sharedCode/src/main/cpp/VROAVRecorderAndroid.cpp
@@ -86,7 +86,16 @@ bool VROAVRecorderAndroid::onRenderedFrameTexture(std::shared_ptr<VRORenderTarge
         _recorderDisplay->setViewport({0, 0, input->getWidth(), input->getHeight()});
 
         driver->bindRenderTarget(_recorderDisplay, VRORenderTargetUnbindOp::Invalidate);
-        _recordingPostProcess->blit({ input->getTexture(0) }, driver);
+
+        // In linear color mode (HDR enabled) the scene framebuffer holds linear RGB values;
+        // gamma-encode them before the encoder reads the surface, otherwise recorded video
+        // is noticeably darker than the live view. In non-linear mode the framebuffer is
+        // already sRGB-encoded and can be blit straight through.
+        if (driver->getColorRenderingMode() == VROColorRenderingMode::Linear) {
+            getGammaPostProcess(driver)->blit({ input->getTexture(0) }, driver);
+        } else {
+            _recordingPostProcess->blit({ input->getTexture(0) }, driver);
+        }
     }
 
     if (_scheduledScreenShot) {
@@ -156,11 +165,16 @@ std::shared_ptr<VRORenderTarget> VROAVRecorderAndroid::bindScreenshotLDRTarget(i
 
 std::shared_ptr<VROImagePostProcess> VROAVRecorderAndroid::getGammaPostProcess(std::shared_ptr<VRODriver> driver) {
     if (!_gammaPostProcess) {
-        std::vector<std::string> samplers = { "hdr_texture", "tone_mapping_mask" };
+        // The sampler name in `samplers` must match the uniform name in the shader
+        // code below — VROImagePostProcess uses `samplers` to locate and bind the
+        // input texture(s) to the corresponding shader uniform(s). A name mismatch
+        // leaves the sampler unbound and the shader reads from texture unit 0 with
+        // no texture attached, producing a black frame.
+        std::vector<std::string> samplers = { "hdr_texture" };
         std::vector<std::string> code = {
                 "const highp float gamma = 2.2;",
-                "uniform sampler2D srgb_texture;",
-                "highp vec4 srgb_color = texture(srgb_texture, v_texcoord);",
+                "uniform sampler2D hdr_texture;",
+                "highp vec4 srgb_color = texture(hdr_texture, v_texcoord);",
                 "highp vec3 gamma_color = pow(srgb_color.xyz, vec3(1.0 / gamma));",
                 "frag_color = vec4(gamma_color, srgb_color.a);",
         };

--- a/android/sharedCode/src/main/cpp/arcore/VROARSessionARCore.cpp
+++ b/android/sharedCode/src/main/cpp/arcore/VROARSessionARCore.cpp
@@ -1637,6 +1637,7 @@ void VROARSessionARCore::checkVPSAvailability(double latitude, double longitude,
 // acquireNewAnchor. No VPS required — placed by GPS + compass + VIO.
 // AR placement math is delegated to RVCCAGeospatialProvider::computeArPosition()
 // (proprietary algorithm inside libreactvisioncca — not exposed in open-source virocore).
+#if RVCCA_AVAILABLE
 static std::shared_ptr<VROGeospatialAnchor> createLocalGPSAnchor(
     arcore::Session *session,
     const VROGeospatialPose &devicePose,
@@ -1682,6 +1683,7 @@ static std::shared_ptr<VROGeospatialAnchor> createLocalGPSAnchor(
     arSession->addAnchor(vAnchor);
     return geoAnchor;
 }
+#endif // RVCCA_AVAILABLE
 
 void VROARSessionARCore::createGeospatialAnchor(double latitude, double longitude, double altitude,
                                                 VROQuaternion quaternion,

--- a/android/sharedCode/src/main/java/com/viro/core/internal/MediaRecorderSurface.java
+++ b/android/sharedCode/src/main/java/com/viro/core/internal/MediaRecorderSurface.java
@@ -105,12 +105,14 @@ public class MediaRecorderSurface {
             return false;
         }
 
-        // Finally, create a window egl surface with the shared eglContext and mRecorderSurface.
-        final int EGL_GL_COLORSPACE_KHR = 0x309D;
-        final int EGL_GL_COLORSPACE_SRGB_KHR = 0x3089;
+        // Create a window egl surface with the shared eglContext and mRecorderSurface.
+        // Only EGL_NONE is passed — no EGL_GL_COLORSPACE_* attribute. On Tensor/Mali drivers,
+        // tagging the encoder-input surface as sRGB causes the driver to gamma-linearize
+        // every framebuffer write and the encoder to emit color_transfer=iec61966-2-1,
+        // producing mis-tagged pixels that no post-hoc remux can repair and throttling GPU
+        // throughput. With no colorspace attribute the encoder emits plain BT.709 SDR
+        // consistently across SoCs.
         final int[] surfaceAttribs = {
-                EGL_GL_COLORSPACE_KHR,
-                EGL_GL_COLORSPACE_SRGB_KHR,
                 EGL14.EGL_NONE
         };
         mEGLSurface = EGL14.eglCreateWindowSurface(mEGLDisplay, configs[0], mRecorderSurface,


### PR DESCRIPTION
**1. Video recording color output & throughput**
On Tensor/Mali the encoder-input EGL surface tagged as sRGB caused `color_transfer=iec61966-2-1` mis-tagging and ~10 fps throttling from per-write gamma. Exynos ignored the flag so this only surfaced on Pixel/Tensor. Drops the flag, applies gamma explicitly for HDR, and fixes a latent sampler-name bug in the gamma post-process shader.

Verified on Pixel 7a (broken) and Samsung A50 (reference); both now emit BT.709 SDR with matching pixels and ~30 fps recording.

**2. RVCCA build guard**
`createLocalGPSAnchor` is defined outside any `#if RVCCA_AVAILABLE` block but dereferences a forward-declared type. Breaks any build without `libreactvisioncca` headers present (public CI included). All call sites are already guarded; wraps the definition to match.