### PR TITLE
fix: meta quest controller support

### DIFF
--- a/ViroRenderer/VROInputControllerBase.cpp
+++ b/ViroRenderer/VROInputControllerBase.cpp
@@ -92,6 +92,12 @@ void VROInputControllerBase::onButtonEvent(int source, VROEventDelegate::ClickSt
     std::shared_ptr<VRONode> &lastClicked = sourceAware
         ? _lastClickedNodesBySource[source]
         : _lastClickedNode;
+    std::shared_ptr<VRONode> &lastHovered = sourceAware
+        ? _lastHoveredNodesBySource[source]
+        : _lastHoveredNode;
+    HoverPending &pending = sourceAware
+        ? _hoverPendingBySource[source]
+        : _hoverPending;
 
     VROVector3f hitLoc = hit->getLocation();
     std::vector<float> pos = {hitLoc.x, hitLoc.y, hitLoc.z};
@@ -99,8 +105,28 @@ void VROInputControllerBase::onButtonEvent(int source, VROEventDelegate::ClickSt
         pos.clear();
     }
 
+    // Hover-hysteresis stickiness: if the user pulled the trigger while the
+    // ray-cast was momentarily jittered off the target — i.e. a hover
+    // pending-exit window is still open and the current hit does not land
+    // on `lastHovered` — re-route the click to `lastHovered`. From the
+    // user's perspective they are still pointing at the last hovered
+    // node; the raycast just blinked off for 1–3 frames. Without this,
+    // the trigger pull resolved against background and JS callers had to
+    // press "dozens of times" to land a single click.
+    std::shared_ptr<VRONode> hitNode = hit->getNode();
+    if (lastHovered != nullptr &&
+        hitNode != lastHovered &&
+        pending.candidateNode != nullptr &&
+        pending.startedMillis >= 0 &&
+        (VROTimeCurrentMillis() - pending.startedMillis) < kHoverHysteresisMillis) {
+        hitNode = lastHovered;
+        pos.clear();  // we don't retain the on-target hit position; payload
+                      // shape matches a background hit. Handlers usually
+                      // care about source / clickState, not position.
+    }
+
     // Notify internal delegates
-    std::shared_ptr<VRONode> focusedNode = getNodeToHandleEvent(VROEventDelegate::EventAction::OnClick, hit->getNode());
+    std::shared_ptr<VRONode> focusedNode = getNodeToHandleEvent(VROEventDelegate::EventAction::OnClick, hitNode);
     for (std::shared_ptr<VROEventDelegate> delegate : _delegates) {
         delegate->onClick(source, focusedNode, clickState, pos);
     }
@@ -113,7 +139,7 @@ void VROInputControllerBase::onButtonEvent(int source, VROEventDelegate::ClickSt
      given Node and source, trigger an onClicked event.
      */
     if (clickState == VROEventDelegate::ClickUp) {
-        if (hit->getNode() == lastClicked) {
+        if (hitNode == lastClicked) {
             for (std::shared_ptr<VROEventDelegate> delegate : _delegates){
                 delegate->onClick(source, focusedNode, VROEventDelegate::ClickState::Clicked, pos);
             }
@@ -130,12 +156,12 @@ void VROInputControllerBase::onButtonEvent(int source, VROEventDelegate::ClickSt
         }
         _lastDraggedNode = nullptr;
     } else if (clickState == VROEventDelegate::ClickDown){
-        lastClicked = hit->getNode();
+        lastClicked = hitNode;
 
         // Identify if object is draggable.
         std::shared_ptr<VRONode> draggableNode
                 = getNodeToHandleEvent(VROEventDelegate::EventAction::OnDrag,
-                                       hit->getNode());
+                                       hitNode);
         
         if (draggableNode == nullptr){
             return;
@@ -490,6 +516,9 @@ void VROInputControllerBase::processGazeEvent(int source) {
     std::shared_ptr<VRONode> &lastHovered = sourceAware
         ? _lastHoveredNodesBySource[source]
         : _lastHoveredNode;
+    HoverPending &pending = sourceAware
+        ? _hoverPendingBySource[source]
+        : _hoverPending;
 
     std::shared_ptr<VRONode> newNode = getNodeToHandleEvent(VROEventDelegate::EventAction::OnHover,
                                                                 hit->getNode());
@@ -497,31 +526,60 @@ void VROInputControllerBase::processGazeEvent(int source) {
         delegate->onGazeHit(source, newNode, *hit.get());
     }
 
+    // Hysteresis: if the hit-test result returns to the currently-hovered
+    // node, cancel any in-flight pending exit and emit nothing — the user
+    // never actually saw a transition.
     if (lastHovered == newNode) {
+        pending = HoverPending{};
         return;
     }
 
     VROVector3f hitLoc = hit->getLocation();
     std::vector<float> pos = {hitLoc.x, hitLoc.y, hitLoc.z};
-    if (hit->isBackgroundHit()) {
+    bool isBgHit = hit->isBackgroundHit();
+    if (isBgHit) {
         pos.clear();
     }
 
+    // First-ever hover into a node (no prior hovered) — fire enter immediately.
+    // No exit to defer, so no point holding it in pending.
+    if (lastHovered == nullptr) {
+        if (newNode && newNode->getEventDelegate()) {
+            newNode->getEventDelegate()->onHover(source, newNode, true, pos);
+        }
+        lastHovered = newNode;
+        pending = HoverPending{};
+        return;
+    }
+
+    // From here on `lastHovered != nullptr` and `newNode != lastHovered`.
+    // Record / update the pending candidate. We confirm the change only
+    // after `kHoverHysteresisMillis` of the new candidate persisting,
+    // which absorbs the 1–3 frame ray-cast jitter of unsteady aim.
+    double now = VROTimeCurrentMillis();
+    if (pending.candidateNode != newNode || pending.startedMillis < 0) {
+        pending.candidateNode  = newNode;
+        pending.candidatePos   = hitLoc;
+        pending.candidateBgHit = isBgHit;
+        pending.startedMillis  = now;
+        return;
+    }
+    if (now - pending.startedMillis < kHoverHysteresisMillis) {
+        // Same candidate as before, but window not elapsed — keep waiting.
+        pending.candidatePos   = hitLoc;
+        pending.candidateBgHit = isBgHit;
+        return;
+    }
+
+    // Window elapsed and candidate held — confirm the transition.
     if (newNode && newNode->getEventDelegate()) {
-        std::shared_ptr<VROEventDelegate> delegate = newNode->getEventDelegate();
-        if (delegate) {
-            delegate->onHover(source, newNode, true, pos);
-        }
+        newNode->getEventDelegate()->onHover(source, newNode, true, pos);
     }
-
     if (lastHovered && lastHovered->getEventDelegate()) {
-        std::shared_ptr<VROEventDelegate> delegate = lastHovered->getEventDelegate();
-        if (delegate) {
-            delegate->onHover(source, lastHovered, false, pos);
-        }
+        lastHovered->getEventDelegate()->onHover(source, lastHovered, false, pos);
     }
-
     lastHovered = newNode;
+    pending = HoverPending{};
 }
 
 void VROInputControllerBase::processOnFuseEvent(int source, std::shared_ptr<VRONode> newNode) {

--- a/ViroRenderer/VROInputControllerBase.h
+++ b/ViroRenderer/VROInputControllerBase.h
@@ -340,6 +340,42 @@ private:
     std::map<int, std::shared_ptr<VRONode>> _lastHoveredNodesBySource;
 
     /*
+     Hover hysteresis state, per source.
+
+     OpenXR controller / hand aim ray-casts naturally jitter — pointing at a
+     small target with a controller held by an unsteady hand causes the
+     hit-test to alternate between the target node and the surrounding
+     background every 1–3 frames. Without hysteresis, every alternation
+     produced an `onHover(false)` / `onHover(true)` pair to JS, which
+     manifested as a flickering hover state and "the click takes dozens of
+     presses to register" — because if the user pulled the trigger on a
+     "miss" frame, `onButtonEvent` resolved the click against the background
+     instead of the target.
+
+     The hysteresis works as a grace period: when the hit changes from
+     `lastHovered` to a different node, we do NOT immediately fire the
+     exit — instead we record the candidate change and the timestamp.
+     If, within `kHoverHysteresisMillis`, the hit returns to `lastHovered`,
+     the exit is cancelled (no `onHover(false)` ever fires). If the new
+     candidate persists past the window, the exit is confirmed and the
+     normal enter/exit dispatch happens.
+
+     The same window is consulted by `onButtonEvent` so that clicks landing
+     on a transient miss-frame are still routed to `lastHovered` if the
+     pending-exit window is still open. That eliminates the "many presses
+     to click" symptom even though the underlying ray-cast still oscillates.
+     */
+    static constexpr double kHoverHysteresisMillis = 75.0;
+    struct HoverPending {
+        std::shared_ptr<VRONode> candidateNode;   // node the hit currently resolves to
+        VROVector3f candidatePos;                 // hit location at the moment of pending start
+        bool candidateBgHit = false;              // whether candidate is a background hit
+        double startedMillis = -1.0;              // wall-clock time when the candidate first appeared
+    };
+    std::map<int, HoverPending> _hoverPendingBySource;
+    HoverPending _hoverPending;  // legacy single-source fallback
+
+    /*
      Returns the first node that is able to handle the event action by bubbling it up.
      If nothing is able to handle the event, nullptr is returned.
      */

--- a/android/sharedCode/src/main/java/com/viro/core/ViroViewOpenXR.java
+++ b/android/sharedCode/src/main/java/com/viro/core/ViroViewOpenXR.java
@@ -129,9 +129,6 @@ public class ViroViewOpenXR extends ViroView {
      */
     public ViroViewOpenXR(final Activity activity, final StartupListener startupListener) {
         super(activity, null);
-        android.util.Log.i("ViroDiag", "ViroViewOpenXR<init> ctor activity=" + activity.getClass().getSimpleName() +
-                "(" + System.identityHashCode(activity) + ") this=" + System.identityHashCode(this) +
-                " ctxClass=" + activity.getClass().getName());
         init(startupListener);
     }
 
@@ -558,13 +555,6 @@ public class ViroViewOpenXR extends ViroView {
     /** @hide */
     @Override
     public void onActivityDestroyed(Activity activity) {
-        Activity host = mWeakActivity.get();
-        boolean match = (host == activity);
-        android.util.Log.i("ViroDiag", "ViroViewOpenXR.onActivityDestroyed activity=" +
-                activity.getClass().getSimpleName() + "(" + System.identityHashCode(activity) +
-                ") host=" + (host == null ? "null" : host.getClass().getSimpleName() +
-                "(" + System.identityHashCode(host) + ")") + " match=" + match +
-                " this=" + System.identityHashCode(this));
         // Only dispose when our host Activity is destroyed. We are now registered
         // with the Application's ActivityLifecycleCallbacks so we receive
         // onActivityDestroyed for *every* Activity in the process — including
@@ -580,10 +570,6 @@ public class ViroViewOpenXR extends ViroView {
     /** @hide */
     @Override
     public void dispose() {
-        android.util.Log.i("ViroDiag", "ViroViewOpenXR.dispose() this=" +
-                System.identityHashCode(this) + " mApplication=" +
-                (mApplication == null ? "null" : "set") +
-                " mDestroyed=" + mDestroyed);
         if (mApplication != null) {
             mApplication.unregisterActivityLifecycleCallbacks(this);
             mApplication = null;

--- a/android/sharedCode/src/main/java/com/viro/core/ViroViewOpenXR.java
+++ b/android/sharedCode/src/main/java/com/viro/core/ViroViewOpenXR.java
@@ -129,6 +129,9 @@ public class ViroViewOpenXR extends ViroView {
      */
     public ViroViewOpenXR(final Activity activity, final StartupListener startupListener) {
         super(activity, null);
+        android.util.Log.i("ViroDiag", "ViroViewOpenXR<init> ctor activity=" + activity.getClass().getSimpleName() +
+                "(" + System.identityHashCode(activity) + ") this=" + System.identityHashCode(this) +
+                " ctxClass=" + activity.getClass().getName());
         init(startupListener);
     }
 
@@ -555,6 +558,13 @@ public class ViroViewOpenXR extends ViroView {
     /** @hide */
     @Override
     public void onActivityDestroyed(Activity activity) {
+        Activity host = mWeakActivity.get();
+        boolean match = (host == activity);
+        android.util.Log.i("ViroDiag", "ViroViewOpenXR.onActivityDestroyed activity=" +
+                activity.getClass().getSimpleName() + "(" + System.identityHashCode(activity) +
+                ") host=" + (host == null ? "null" : host.getClass().getSimpleName() +
+                "(" + System.identityHashCode(host) + ")") + " match=" + match +
+                " this=" + System.identityHashCode(this));
         // Only dispose when our host Activity is destroyed. We are now registered
         // with the Application's ActivityLifecycleCallbacks so we receive
         // onActivityDestroyed for *every* Activity in the process — including
@@ -570,6 +580,10 @@ public class ViroViewOpenXR extends ViroView {
     /** @hide */
     @Override
     public void dispose() {
+        android.util.Log.i("ViroDiag", "ViroViewOpenXR.dispose() this=" +
+                System.identityHashCode(this) + " mApplication=" +
+                (mApplication == null ? "null" : "set") +
+                " mDestroyed=" + mDestroyed);
         if (mApplication != null) {
             mApplication.unregisterActivityLifecycleCallbacks(this);
             mApplication = null;

--- a/ios/Podfile.visionos
+++ b/ios/Podfile.visionos
@@ -1,0 +1,10 @@
+platform :visionos, '1.0'
+workspace 'ViroRenderer'
+
+# No ARCore, no GVRAudioSDK — all iOS-only.
+# ViroKit visionOS uses Metal + CompositorServices directly.
+# This intentionally empty pod target gives us clean CocoaPods integration
+# (xcconfig stubs, PODS_ROOT, etc.) without any iOS-only framework references.
+target 'ViroKit' do
+  use_frameworks!
+end

--- a/ios/ViroKit-visionOS.xcconfig
+++ b/ios/ViroKit-visionOS.xcconfig
@@ -1,0 +1,197 @@
+// ViroKit-visionOS.xcconfig
+// Build settings applied by build_visionos.sh when archiving for xros / xrsimulator.
+//
+// Strategy: exclude iOS-only source files from the xros compilation unit.
+// VRODriverVisionOS (in VisionOS/ subdirectory) provides Metal-only replacements.
+// No source files are modified — the exclusions live entirely here.
+
+// ── SDK / deployment ──────────────────────────────────────────────────────────
+SDKROOT = xros
+SUPPORTED_PLATFORMS = xros xrsimulator
+XROS_DEPLOYMENT_TARGET = 1.0
+TARGETED_DEVICE_FAMILY = 7
+
+// ── Metal-only path ───────────────────────────────────────────────────────────
+// VRODefines.h defaults VRO_METAL=0; we force it on for visionOS.
+OTHER_CFLAGS = $(inherited) -DVRO_METAL=1
+
+// ── Linker ────────────────────────────────────────────────────────────────────
+// The Xcode project hard-links -lGVRAudioSDK (iOS-only pod).
+// Override for xros to avoid "library not found" linker errors.
+OTHER_LDFLAGS[sdk=xros*] =
+
+// Library search paths for xros: the project only defines iphoneos*/iphonesimulator*
+// variants, so nothing is inherited for xros. Point to the arm64 static libs.
+// These were compiled for iOS arm64 but contain only ARM64 object code and link fine
+// for visionOS (same ISA). We add -Wl,-w to suppress platform-mismatch warnings.
+LIBRARY_SEARCH_PATHS[sdk=xros*] = $(inherited) "$(PROJECT_DIR)/Libraries/freetype/armv7_arm64" "$(PROJECT_DIR)/Libraries/protobuf/armv7_arm64" "$(PROJECT_DIR)/Libraries/bullet/armv7_arm64" "$(PROJECT_DIR)/Libraries/harfbuzz/armv7_arm64" "$(PROJECT_DIR)/Libraries/reactvisioncca/arm64"
+
+// Stub frameworks for iOS-only system frameworks that appear in the Frameworks
+// build phase but are unavailable on visionOS. The stubs export zero symbols so
+// the linker is satisfied; no runtime dependency is added.
+FRAMEWORK_SEARCH_PATHS[sdk=xros*] = $(inherited) "$(SRCROOT)/Stubs"
+
+// GoogleUtilities (pulled in by ARCore) has functions that don't return on visionOS
+// code paths because it checks TARGET_OS_IOS/TVOS/OSX but not TARGET_OS_VISION.
+// ARCore is iOS-only and unused on xros — suppress the error so the build proceeds.
+OTHER_CFLAGS[sdk=xros*] = $(inherited) -Wno-return-type
+
+// ── Header search paths ───────────────────────────────────────────────────────
+// ViroKit/ files include each other by basename (e.g. "VROAudioPlayeriOS.h"),
+// so the ViroKit source directory must be in the search path.
+HEADER_SEARCH_PATHS = $(inherited) "$(SRCROOT)/ViroKit" "$(SRCROOT)/ViroKit/VisionOS"
+
+// ── Excluded iOS-only sources ─────────────────────────────────────────────────
+// These files use OpenGL ES, GLKit, AVFoundation camera, or iOS ARKit APIs
+// that do not exist on visionOS.  VRODriverVisionOS provides Metal replacements.
+//
+// Format: space-separated basenames (or glob patterns) — no directory prefix.
+
+EXCLUDED_SOURCE_FILE_NAMES[sdk=xros*] = \
+    VRODisplayOpenGLiOS.h \
+    VRODisplayOpenGLiOS.cpp \
+    VRODisplayOpenGLGVR.h \
+    VRODriverOpenGLiOS.h \
+    VRODriverOpenGLiOS.cpp \
+    VROVideoTextureCacheOpenGL.h \
+    VROVideoTextureCacheOpenGL.cpp \
+    VRODistortionRenderer.h \
+    VRODistortionRenderer.cpp \
+    VROViewScene.h \
+    VROViewScene.mm \
+    VROViewAR.h \
+    VROViewAR.mm \
+    VROViewMetal.h \
+    VROViewMetal.m \
+    VROViewRecorder.h \
+    VROViewRecorder.mm \
+    VROAVCaptureController.h \
+    VROAVCaptureController.cpp \
+    VROCameraTextureiOS.h \
+    VROCameraTextureiOS.cpp \
+    VROObjectRecognizeriOS.h \
+    VROObjectRecognizeriOS.cpp \
+    VROBodyTrackerYolo.h \
+    VROBodyTrackerYolo.cpp \
+    VROMonocularDepthEstimator.h \
+    VROMonocularDepthEstimator.mm \
+    VROARSessioniOS.h \
+    VROARSessioniOS.cpp \
+    VROARCameraiOS.h \
+    VROARCameraiOS.cpp \
+    VROARFrameiOS.h \
+    VROARFrameiOS.cpp \
+    VROARHitTestResultiOS.h \
+    VROARHitTestResultiOS.mm \
+    VROARImageTargetiOS.h \
+    VROARImageTargetiOS.cpp \
+    VROARObjectTargetiOS.h \
+    VROARObjectTargetiOS.cpp \
+    VROARAnchoriOS.h \
+    VROARAnchoriOS.cpp \
+    VROARCameraInertial.h \
+    VROARCameraInertial.cpp \
+    VROARFrameInertial.h \
+    VROARFrameInertial.cpp \
+    VROVideoTextureiOS.h \
+    VROVideoTextureiOS.cpp \
+    VROAudioPlayeriOS.h \
+    VROAudioPlayeriOS.cpp \
+    VROSoundDelegateiOS.h \
+    VROTypefaceiOS.h \
+    VROTypefaceiOS.cpp \
+    VROAnimBodyDataiOS.h \
+    VROAnimBodyDataiOS.cpp \
+    VROARNodeDelegateiOS.h \
+    VROARSceneDelegateiOS.h \
+    VROARCameraPrerecorded.h \
+    VROARCameraPrerecorded.cpp \
+    VROApiKeyValidatorDynamo.h \
+    VROApiKeyValidatorDynamo.m \
+    VROApiKeyMetrics.h \
+    VROApiKeyMetrics.m \
+    VROApiMetricsIncrementRequest.h \
+    VROApiMetricsIncrementRequest.m \
+    VROApiMetricsRequest.h \
+    VROApiMetricsRequest.m \
+    VROWeakProxy.h \
+    VROWeakProxy.mm \
+    VROHeadTracker.h \
+    VROHeadTracker.cpp \
+    OrientationEKF.h \
+    OrientationEKF.mm \
+    SO3Util.h \
+    SO3Util.mm \
+    Matrix3x3d.h \
+    Matrix3x3d.mm \
+    Vector3d.h \
+    Vector3d.mm \
+    VROBodyIKController.h \
+    VROBodyIKController.cpp \
+    VROBodyTrackerController.h \
+    VROBodyTrackerController.cpp \
+    VROBodyPlayeriOS.h \
+    VROBodyTrackerTest.h \
+    VROBodyTrackerTest.cpp \
+    VROObjectRecognitionTest.h \
+    VROObjectRecognitionTest.cpp \
+    VROBodyRecognitionTest.h \
+    VROBodyRecognitionTest.cpp \
+    VROBodyMesherTest.h \
+    VROBodyMesherTest.cpp \
+    VROTextTest.h \
+    VROTextTest.cpp \
+    VROARPlaneTest.h \
+    VROARPlaneTest.cpp \
+    VROAnimatedTextureOpenGL.h \
+    VROAnimatedTextureOpenGL.cpp \
+    VRODisplayOpenGL.h \
+    VRODriverOpenGL.h \
+    VRODriverOpenGL.cpp \
+    VROGeometrySubstrateOpenGL.h \
+    VROGeometrySubstrateOpenGL.cpp \
+    VROGlyphAtlasOpenGL.h \
+    VROGlyphAtlasOpenGL.cpp \
+    VROGlyphOpenGL.h \
+    VROGlyphOpenGL.cpp \
+    VROImagePostProcessOpenGL.h \
+    VROImagePostProcessOpenGL.cpp \
+    VROMaterialSubstrateOpenGL.h \
+    VROMaterialSubstrateOpenGL.cpp \
+    VRORenderTargetOpenGL.h \
+    VRORenderTargetOpenGL.cpp \
+    VROTextureSubstrateOpenGL.h \
+    VROTextureSubstrateOpenGL.cpp \
+    VROVertexBufferOpenGL.h \
+    VROVertexBufferOpenGL.cpp \
+    VROShaderProgram.h \
+    VROShaderProgram.cpp \
+    VROShaderFactory.h \
+    VROShaderFactory.cpp \
+    VROLightingUBO.h \
+    VROLightingUBO.cpp \
+    VROBoneUBO.h \
+    VROBoneUBO.cpp \
+    VROParticleUBO.h \
+    VROParticleUBO.cpp \
+    VROMaterialShaderBinding.h \
+    VROMaterialShaderBinding.cpp \
+    VROVisionEngine.h \
+    VROVisionEngine.cpp \
+    VROSoundGVR.h \
+    VROSoundGVR.cpp \
+    VROScreen.h \
+    VROScreen.cpp \
+    VROSkeletonRenderer.h \
+    VROSkeletonRenderer.cpp \
+    VROBodySurfaceRenderer.h \
+    VROBodySurfaceRenderer.cpp \
+    VROImageShaderProgram.h \
+    VROImageShaderProgram.cpp \
+    VROGVRUtil.h \
+    VROGVRUtil.cpp \
+    VROGeometrySubstrateMetal.cpp \
+    VROCloudAnchorProviderReactVision.h \
+    VROCloudAnchorProviderReactVision.mm \
+    VROCloudAnchorProviderARCore.h \
+    VROCloudAnchorProviderARCore.mm

--- a/ios/ViroKit.podspec
+++ b/ios/ViroKit.podspec
@@ -27,7 +27,12 @@ Pod::Spec.new do |s|
   s.author              = 'ReactVision'
   s.requires_arc        = true
   s.platform            = :ios, '13.0'
+  s.visionos.deployment_target = '1.0'
   s.dependency 'React'
+
+  # visionOS requires CompositorServices for the immersive render loop.
+  # Metal and MetalKit are available on both iOS and visionOS.
+  s.visionos.frameworks = ['Metal', 'MetalKit', 'CompositorServices', 'ARKit']
 
   # ARCore frameworks and Firebase dependencies are weak-linked via post_install hook
   # This prevents linker errors when ARCore pods are not installed

--- a/ios/ViroKit/VisionOS/VRODriverVisionOS.h
+++ b/ios/ViroKit/VisionOS/VRODriverVisionOS.h
@@ -1,0 +1,152 @@
+// VRODriverVisionOS.h
+// ViroKit — visionOS
+//
+// Concrete VRODriver implementation for visionOS / CompositorServices.
+//
+// Extends VRODriverMetal and provides no-op or minimal implementations for all
+// remaining pure-virtual VRODriver methods.  Critical overrides:
+//   • getDisplay()        — returns _displayTarget (VRORenderTargetMetal)
+//   • bindRenderTarget()  — no-op (encoder managed externally by Swift)
+//   • setCullMode()       — forwards to the active MTLRenderCommandEncoder
+//   • setBlendingMode()   — no-op (blend state is baked into pipeline objects)
+//   • getColorRenderingMode() — NonLinear (avoids HDR path in VROChoreographer)
+//   • newRenderTarget()   — returns a stub VRORenderTargetMetal
+//   • newTextureSubstrate()  — delegates to VROTextureSubstrateMetal
+
+#ifndef VRODriverVisionOS_h
+#define VRODriverVisionOS_h
+
+#include "VRODefines.h"
+#if VRO_METAL
+
+#include "VRODriverMetal.h"
+#include "VRORenderTargetMetal.h"
+#include "VROTextureSubstrateMetal.h"
+#include "VROMaterial.h"
+#include <memory>
+
+class VROFrameScheduler;
+
+class VRODriverVisionOS : public VRODriverMetal,
+                          public std::enable_shared_from_this<VRODriverVisionOS> {
+public:
+
+    VRODriverVisionOS(id <MTLDevice> device);
+    virtual ~VRODriverVisionOS() {}
+
+    // ── Active encoder ───────────────────────────────────────────────────────
+    // Must be called by the Swift render loop before every VRORenderer::renderEye()
+    // invocation.  The encoder is also forwarded to the display render target so
+    // that setViewport() takes effect immediately.
+    void setActiveEncoder(id <MTLRenderCommandEncoder> encoder);
+
+    // ── VRODriver pure-virtual overrides ─────────────────────────────────────
+
+    // Frame / eye lifecycle — no-op stubs
+    void willRenderFrame(const VRORenderContext &context) override {}
+    void didRenderFrame(const VROFrameTimer &timer, const VRORenderContext &context) override {}
+    void willRenderEye(const VRORenderContext &context) override {}
+    void didRenderEye(const VRORenderContext &context) override {}
+    void pause()  override {}
+    void resume() override {}
+
+    // GPU type
+    void      readGPUType() override {}
+    VROGPUType getGPUType()  override { return VROGPUType::Normal; }
+
+    // Framebuffer read-back — not applicable
+    void readDisplayFramebuffer() override {}
+
+    // Texture-unit / shader binding — OpenGL concepts, no-op for Metal
+    void setActiveTextureUnit(int) override {}
+    void bindTexture(int, int) override {}
+    void bindTexture(int, int, int) override {}
+    void setDepthWritingEnabled(bool) override {}
+    void setDepthReadingEnabled(bool) override {}
+    void setStencilTestEnabled(bool) override {}
+
+    // Cull mode — forwarded to the active encoder
+    void setCullMode(VROCullMode cullMode) override;
+
+    // Color mask — no-op (would need to be baked into pipeline state; deferred)
+    void setRenderTargetColorWritingMask(VROColorMask) override {}
+    void setMaterialColorWritingMask(VROColorMask) override {}
+
+    // Shader binding — managed via MTLRenderPipelineState; no-op for Metal
+    void bindShader(std::shared_ptr<VROShaderProgram>) override {}
+    void unbindShader() override {}
+
+    // Render target management
+    bool bindRenderTarget(std::shared_ptr<VRORenderTarget> target,
+                          VRORenderTargetUnbindOp unbindOp) override;
+    void unbindRenderTarget() override {}
+    std::shared_ptr<VRORenderTarget> getRenderTarget() override { return _displayTarget; }
+
+    std::shared_ptr<VRORenderTarget> getDisplay() override { return _displayTarget; }
+
+    std::shared_ptr<VRORenderTarget> newRenderTarget(VRORenderTargetType type,
+                                                     int numAttachments,
+                                                     int numImages,
+                                                     bool enableMipmaps,
+                                                     bool needsDepthStencil) override;
+
+    // Color rendering — NonLinear avoids the HDR / bloom paths in VROChoreographer
+    VROColorRenderingMode getColorRenderingMode() override {
+        return VROColorRenderingMode::NonLinear;
+    }
+    void setHasSoftwareGammaPass(bool) override {}
+    bool hasSoftwareGammaPass() const   override { return false; }
+    bool isBloomSupported()     override { return false; }
+
+    // Blend mode — baked per-pipeline in VROGeometrySubstrateMetal; no-op here
+    void setBlendingMode(VROBlendMode) override {}
+
+    // Texture substrate — bridge to VROTextureSubstrateMetal
+    VROTextureSubstrate *newTextureSubstrate(VROTextureType type,
+                                             VROTextureFormat format,
+                                             VROTextureInternalFormat internalFormat,
+                                             bool sRGB,
+                                             VROMipmapMode mipmapMode,
+                                             std::vector<std::shared_ptr<VROData>> &data,
+                                             int width, int height,
+                                             std::vector<uint32_t> mipSizes,
+                                             VROWrapMode wrapS, VROWrapMode wrapT,
+                                             VROFilterMode minFilter,
+                                             VROFilterMode magFilter,
+                                             VROFilterMode mipFilter) override;
+
+    // Vertex buffer — Metal geometry substrate uses MTLBuffer directly; return null
+    std::shared_ptr<VROVertexBuffer> newVertexBuffer(std::shared_ptr<VROData>) override {
+        return nullptr;
+    }
+
+    // Image post-process — not needed for basic scenes; return null stub
+    std::shared_ptr<VROImagePostProcess> newImagePostProcess(std::shared_ptr<VROShaderProgram>) override {
+        return nullptr;
+    }
+
+    // Sound — not supported; return null
+    std::shared_ptr<VROSound> newSound(std::shared_ptr<VROSoundData>, VROSoundType) override {
+        return nullptr;
+    }
+    std::shared_ptr<VROAudioPlayer> newAudioPlayer(std::shared_ptr<VROSoundData>) override {
+        return nullptr;
+    }
+    void setSoundRoom(float, float, float, std::string, std::string, std::string) override {}
+
+    // Typeface — not yet ported; pabort for debugging
+    std::shared_ptr<VROTypefaceCollection> newTypefaceCollection(std::string, int,
+                                                                  VROFontStyle, VROFontWeight) override;
+
+    // Frame scheduler — not needed for visionOS POC
+    std::shared_ptr<VROFrameScheduler> getFrameScheduler() override { return nullptr; }
+
+    // Raw graphics context — not applicable
+    void *getGraphicsContext() override { return nullptr; }
+
+private:
+    std::shared_ptr<VRORenderTargetMetal> _displayTarget;
+};
+
+#endif  // VRO_METAL
+#endif  // VRODriverVisionOS_h

--- a/ios/ViroKit/VisionOS/VRODriverVisionOS.mm
+++ b/ios/ViroKit/VisionOS/VRODriverVisionOS.mm
@@ -1,0 +1,101 @@
+// VRODriverVisionOS.mm
+// ViroKit — visionOS
+
+#include "VRODriverVisionOS.h"
+#if VRO_METAL
+
+#include "VRORenderTargetMetal.h"
+#include "VROTextureSubstrateMetal.h"
+#include "VROLog.h"
+#include "VROData.h"
+
+// ── Constructor ──────────────────────────────────────────────────────────────
+
+VRODriverVisionOS::VRODriverVisionOS(id <MTLDevice> device)
+    : VRODriverMetal(device)
+{
+    // CompositorServices pixel formats (matching ViroImmersiveSpace.swift LayerConfiguration)
+    setColorPixelFormat(MTLPixelFormatBGRA8Unorm_sRGB);
+    setDepthPixelFormat(MTLPixelFormatDepth32Float);
+    setSampleCount(1);
+
+    _displayTarget = std::make_shared<VRORenderTargetMetal>();
+}
+
+// ── Active encoder ────────────────────────────────────────────────────────────
+
+void VRODriverVisionOS::setActiveEncoder(id <MTLRenderCommandEncoder> encoder) {
+    VRODriverMetal::setActiveEncoder(encoder);
+    _displayTarget->setEncoder(encoder);
+}
+
+// ── Render target management ──────────────────────────────────────────────────
+
+bool VRODriverVisionOS::bindRenderTarget(std::shared_ptr<VRORenderTarget> target,
+                                          VRORenderTargetUnbindOp unbindOp) {
+    // The encoder is created externally by the Swift render loop.
+    // We don't create new encoders here — just track the active target.
+    // Return false to indicate the target was already "bound" (no state change).
+    return false;
+}
+
+std::shared_ptr<VRORenderTarget> VRODriverVisionOS::newRenderTarget(
+    VRORenderTargetType type,
+    int numAttachments,
+    int numImages,
+    bool enableMipmaps,
+    bool needsDepthStencil)
+{
+    // Return a stub render target.  With HDR and MRT disabled, these targets
+    // are created by the choreographer but never used for actual rendering.
+    return std::make_shared<VRORenderTargetMetal>();
+}
+
+// ── Cull mode ─────────────────────────────────────────────────────────────────
+
+void VRODriverVisionOS::setCullMode(VROCullMode cullMode) {
+    id <MTLRenderCommandEncoder> encoder = getActiveEncoder();
+    if (!encoder) { return; }
+    switch (cullMode) {
+        case VROCullMode::None:  [encoder setCullMode:MTLCullModeNone];  break;
+        case VROCullMode::Back:  [encoder setCullMode:MTLCullModeBack];  break;
+        case VROCullMode::Front: [encoder setCullMode:MTLCullModeFront]; break;
+    }
+}
+
+// ── Texture substrate ─────────────────────────────────────────────────────────
+
+VROTextureSubstrate *VRODriverVisionOS::newTextureSubstrate(
+    VROTextureType type,
+    VROTextureFormat format,
+    VROTextureInternalFormat internalFormat,
+    bool sRGB,
+    VROMipmapMode mipmapMode,
+    std::vector<std::shared_ptr<VROData>> &data,
+    int width, int height,
+    std::vector<uint32_t> mipSizes,
+    VROWrapMode wrapS, VROWrapMode wrapT,
+    VROFilterMode minFilter, VROFilterMode magFilter, VROFilterMode mipFilter)
+{
+    if (data.empty() || !data[0]) {
+        pinfo("VRODriverVisionOS: newTextureSubstrate called with no data");
+        return nullptr;
+    }
+    // Use the first mip level.  VROTextureSubstrateMetal will upload the raw
+    // bytes to a Metal texture with the specified dimensions.
+    // shared_from_this() returns shared_ptr<VRODriverVisionOS>; upcast to VRODriver
+    // before passing so the lvalue reference binds correctly.
+    std::shared_ptr<VRODriver> driverPtr = std::static_pointer_cast<VRODriver>(shared_from_this());
+    return new VROTextureSubstrateMetal(type, format, data[0], width, height, driverPtr);
+}
+
+// ── Typeface ──────────────────────────────────────────────────────────────────
+
+std::shared_ptr<VROTypefaceCollection> VRODriverVisionOS::newTypefaceCollection(
+    std::string typefaces, int size, VROFontStyle style, VROFontWeight weight)
+{
+    // Text rendering is not yet ported to Metal — Week 3 task.
+    pabort("VRODriverVisionOS: newTypefaceCollection not yet implemented for visionOS");
+}
+
+#endif  // VRO_METAL

--- a/ios/ViroKit/VisionOS/VRORenderTargetMetal.h
+++ b/ios/ViroKit/VisionOS/VRORenderTargetMetal.h
@@ -1,0 +1,100 @@
+// VRORenderTargetMetal.h
+// ViroKit — visionOS
+//
+// Minimal VRORenderTarget implementation for Metal / CompositorServices.
+//
+// In the visionOS rendering path the platform (ViroImmersiveRenderer.swift) is
+// responsible for creating MTLRenderCommandEncoder objects — one per eye — and
+// handing them to VRODriverVisionOS via setActiveEncoder().  This class just
+// satisfies the VRORenderTarget interface so VROChoreographer (which creates and
+// tracks a few render targets even when HDR is off) does not crash.
+//
+// The "display" target (returned by VRODriverVisionOS::getDisplay()) also tracks
+// the current encoder and forwards setViewport() to it so that the choreographer
+// can set the Metal viewport in the normal way.
+
+#ifndef VRORenderTargetMetal_h
+#define VRORenderTargetMetal_h
+
+#include "VRODefines.h"
+#if VRO_METAL
+
+#include "VRORenderTarget.h"
+#include "VROViewport.h"
+#include <Metal/Metal.h>
+
+class VRORenderTargetMetal : public VRORenderTarget {
+public:
+
+    VRORenderTargetMetal()
+        : VRORenderTarget(VRORenderTargetType::Display, 1)
+        , _encoder(nil)
+        , _width(1), _height(1) {}
+
+    virtual ~VRORenderTargetMetal() {}
+
+    // ── Encoder plumbing ──────────────────────────────────────────────────────
+    void setEncoder(id <MTLRenderCommandEncoder> encoder) {
+        _encoder = encoder;
+        // Re-apply stored viewport to the new encoder if we have one.
+        if (_encoder && _viewportSet) {
+            [_encoder setViewport:_metalViewport];
+        }
+    }
+    id <MTLRenderCommandEncoder> getEncoder() const { return _encoder; }
+
+    // ── VRORenderTarget interface ─────────────────────────────────────────────
+
+    bool setViewport(VROViewport viewport) override {
+        _width  = viewport.getWidth();
+        _height = viewport.getHeight();
+        _metalViewport = { (double)viewport.getX(), (double)viewport.getY(),
+                           (double)_width, (double)_height, 0.0, 1.0 };
+        _viewportSet = true;
+        if (_encoder) {
+            [_encoder setViewport:_metalViewport];
+        }
+        return true;
+    }
+
+    bool   hydrate()    override { return true; }
+    int    getWidth()   const override { return _width; }
+    int    getHeight()  const override { return _height; }
+    void   bind()       override {}
+    void   bindRead()   override {}
+    void   invalidate() override {}
+
+    void blitColor(std::shared_ptr<VRORenderTarget>, bool, std::shared_ptr<VRODriver>) override {}
+    void blitStencil(std::shared_ptr<VRORenderTarget>, bool, std::shared_ptr<VRODriver>) override {}
+    void blitDepth(std::shared_ptr<VRORenderTarget>) override {}
+    void deleteFramebuffers()  override {}
+    bool restoreFramebuffers() override { return true; }
+
+    bool hasTextureAttached(int)  override { return false; }
+    void clearTextures()          override {}
+    bool attachNewTextures()      override { return true; }
+    void setTextureImageIndex(int, int) override {}
+    void setTextureCubeFace(int, int, int) override {}
+    void setMipLevel(int, int) override {}
+    void attachTexture(std::shared_ptr<VROTexture>, int) override {}
+    const std::shared_ptr<VROTexture> getTexture(int) const override { return nullptr; }
+
+    void clearStencil()       override {}
+    void clearDepth()         override {}
+    void clearColor()         override {}
+    void clearDepthAndColor() override {}
+
+    void enablePortalStencilWriting(VROFace) override {}
+    void enablePortalStencilRemoval(VROFace) override {}
+    void disablePortalStencilWriting(VROFace) override {}
+    void setPortalStencilPassFunction(VROFace, VROStencilFunc, int) override {}
+
+private:
+    id <MTLRenderCommandEncoder> _encoder;
+    MTLViewport _metalViewport = {};
+    bool _viewportSet = false;
+    int _width, _height;
+};
+
+#endif  // VRO_METAL
+#endif  // VRORenderTargetMetal_h

--- a/ios/build_visionos.sh
+++ b/ios/build_visionos.sh
@@ -1,0 +1,230 @@
+#!/bin/bash
+# build_visionos.sh
+# Compila ViroKit para visionOS (device only — xros) y genera:
+#   - ViroKit.xcframework  (device slice únicamente, igual que iOS)
+#   - include/             (headers planos para HEADER_SEARCH_PATHS)
+#
+# Output: viro/ios/dist/ViroRendererVisionOS/
+#
+# Uso:
+#   cd virocore/ios && ./build_visionos.sh
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+WORKSPACE="$SCRIPT_DIR/ViroRenderer.xcworkspace"
+SCHEME="ViroKit"
+
+# Destino de salida — relativo a virocore/ios/ → ../../viro/ios/dist/
+VIRO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)/viro"
+OUT_DIR="$VIRO_ROOT/ios/dist/ViroRendererVisionOS"
+ARCHIVES="/tmp/virokit-visionos-$$"
+
+PODS_DIR="$SCRIPT_DIR/Pods"
+PODS_IOS_BAK="$SCRIPT_DIR/Pods.ios_bak"
+PODS_XROS="$SCRIPT_DIR/Pods.xros"
+
+echo "=== ViroKit visionOS build (device only) ==="
+echo "  Workspace : $WORKSPACE"
+echo "  Output    : $OUT_DIR"
+echo ""
+
+mkdir -p "$ARCHIVES" "$OUT_DIR"
+
+# xcconfig que excluye archivos iOS-only y activa VRO_METAL=1
+XCCONFIG="$SCRIPT_DIR/ViroKit-visionOS.xcconfig"
+
+# ── visionOS Pods setup ────────────────────────────────────────────────────────
+# Podfile.visionos has NO ARCore/GVR pods — CocoaPods generates a clean Pods/
+# project with no iOS-only framework references at all. No patching needed.
+#
+# First run: install visionOS pods once (no network download — zero pods).
+# Subsequent runs: just swap the Pods directory.
+
+setup_xros_pods() {
+  if [ ! -d "$PODS_XROS" ]; then
+    echo "→ Installing visionOS pods (first time — no downloads)..."
+    # CocoaPods always reads 'Podfile' — swap ours in temporarily
+    [ -d "$PODS_DIR" ] && mv "$PODS_DIR" "$PODS_IOS_BAK"
+    mv "$SCRIPT_DIR/Podfile" "$SCRIPT_DIR/Podfile.ios_bak"
+    cp "$SCRIPT_DIR/Podfile.visionos" "$SCRIPT_DIR/Podfile"
+    (cd "$SCRIPT_DIR" && pod install --silent) || {
+      mv "$SCRIPT_DIR/Podfile.ios_bak" "$SCRIPT_DIR/Podfile"
+      [ -d "$PODS_IOS_BAK" ] && mv "$PODS_IOS_BAK" "$PODS_DIR"
+      echo "✗ pod install failed" >&2; exit 1
+    }
+    mv "$SCRIPT_DIR/Podfile.ios_bak" "$SCRIPT_DIR/Podfile"
+    mv "$PODS_DIR" "$PODS_XROS"
+    [ -d "$PODS_IOS_BAK" ] && mv "$PODS_IOS_BAK" "$PODS_DIR"
+    echo "  ✓ Pods.xros/ created"
+  fi
+}
+
+swap_to_xros_pods() {
+  [ -d "$PODS_DIR" ] && mv "$PODS_DIR" "$PODS_IOS_BAK"
+  mv "$PODS_XROS" "$PODS_DIR"
+  echo "  ✓ Using visionOS Pods (no ARCore/GVR)"
+}
+
+restore_ios_pods() {
+  # Called by trap on exit — restore regardless of success/failure
+  if [ -d "$PODS_IOS_BAK" ]; then
+    [ -d "$PODS_DIR" ] && mv "$PODS_DIR" "$PODS_XROS" 2>/dev/null || true
+    mv "$PODS_IOS_BAK" "$PODS_DIR"
+  fi
+}
+
+# ── visionOS static library repathing ─────────────────────────────────────────
+# iOS arm64 static archives (.a) have their object files tagged as built for iOS.
+# The Apple linker rejects them when linking for visionOS (same ISA, different platform).
+# We repath once per library by: (1) extracting arm64 objects, (2) retagging each
+# object file from iphoneos to xros using vtool, (3) repacking.
+# Repathed libs are cached in Libraries.xros/ and swapped in around the archive step.
+
+LIBS_XROS="$SCRIPT_DIR/Libraries.xros"
+
+# Map: iOS library paths relative to SCRIPT_DIR
+IOS_LIBS=(
+  "Libraries/freetype/armv7_arm64/libfreetype.a"
+  "Libraries/protobuf/armv7_arm64/libprotobuf-lite.a"
+  "Libraries/harfbuzz/armv7_arm64/harfbuzz.a"
+  "Libraries/bullet/armv7_arm64/libBulletCollision.a"
+  "Libraries/bullet/armv7_arm64/libBulletDynamics.a"
+  "Libraries/bullet/armv7_arm64/libBulletSoftBody.a"
+  "Libraries/bullet/armv7_arm64/libLinearMath.a"
+  "Libraries/reactvisioncca/arm64/libreactvisioncca.a"
+)
+
+repath_lib_for_xros() {
+  local src="$SCRIPT_DIR/$1"
+  local dst="$LIBS_XROS/$1"
+  [ -f "$dst" ] && return  # already done
+  mkdir -p "$(dirname "$dst")"
+  local tmp; tmp=$(mktemp -d)
+  # Extract arm64-only slice (strip armv7 if fat binary)
+  if xcrun lipo -thin arm64 "$src" -output "$tmp/thin" 2>/dev/null; then
+    :
+  else
+    cp "$src" "$tmp/thin"  # already thin or single-arch
+  fi
+  # Check if it's an AR archive or a Mach-O binary (e.g. dylib with .a extension)
+  local filetype; filetype=$(file "$tmp/thin" 2>/dev/null || echo "unknown")
+  if echo "$filetype" | grep -q "ar archive"; then
+    # Static archive: extract .o files and repath each one
+    (cd "$tmp" && xcrun ar -x thin 2>/dev/null)
+    rm -f "$tmp/thin" "$tmp/__.SYMDEF"* 2>/dev/null || true
+    shopt -s nullglob
+    objs=("$tmp"/*.o)
+    shopt -u nullglob
+    for obj in "${objs[@]}"; do
+      xcrun vtool -arch arm64 -set-build-version visionos 1.0 1.0 -replace \
+                  -output "$obj" "$obj" 2>/dev/null || true
+    done
+    if [ ${#objs[@]} -gt 0 ]; then
+      xcrun ar rcs "$dst" "${objs[@]}"
+    else
+      cp "$src" "$dst"
+    fi
+  else
+    # Mach-O binary (dylib / .a-disguised-dylib): repath directly
+    xcrun vtool -set-build-version visionos 1.0 1.0 -replace \
+                -output "$dst" "$tmp/thin" 2>/dev/null || cp "$tmp/thin" "$dst"
+  fi
+  rm -rf "$tmp"
+  echo "  ✓ $(basename "$dst") → xros"
+}
+
+setup_xros_libs() {
+  local needs_repath=0
+  for lib in "${IOS_LIBS[@]}"; do
+    [ -f "$LIBS_XROS/$lib" ] || { needs_repath=1; break; }
+  done
+  if [ "$needs_repath" -eq 1 ]; then
+    echo "→ Repathing static libs from iOS → visionOS (one time)..."
+    for lib in "${IOS_LIBS[@]}"; do
+      repath_lib_for_xros "$lib"
+    done
+  fi
+}
+
+swap_to_xros_libs() {
+  for lib in "${IOS_LIBS[@]}"; do
+    local ios="$SCRIPT_DIR/$lib"
+    local xros="$LIBS_XROS/$lib"
+    [ -f "$ios" ] && mv "$ios" "${ios}.ios_bak"
+    cp "$xros" "$ios"
+  done
+  echo "  ✓ visionOS libs swapped in"
+}
+
+restore_ios_libs() {
+  for lib in "${IOS_LIBS[@]}"; do
+    local ios="$SCRIPT_DIR/$lib"
+    local bak="${ios}.ios_bak"
+    [ -f "$bak" ] && mv "$bak" "$ios"
+  done
+}
+
+setup_xros_libs
+swap_to_xros_libs
+
+# Always restore iOS Pods and libs on exit (success or failure)
+trap "restore_ios_libs; restore_ios_pods" EXIT
+
+setup_xros_pods
+
+echo "→ Swapping to visionOS Pods..."
+swap_to_xros_pods
+
+# Flags comunes para xcodebuild
+# SDKROOT + SUPPORTED_PLATFORMS must be on the command line (not just xcconfig)
+# so xcodebuild resolves the visionOS destination before applying xcconfig.
+XCFLAGS=(
+  -workspace "$WORKSPACE"
+  -scheme    "$SCHEME"
+  -xcconfig  "$XCCONFIG"
+  SKIP_INSTALL=NO
+  BUILD_LIBRARY_FOR_DISTRIBUTION=YES
+  SDKROOT=xros
+  SUPPORTED_PLATFORMS="xros xrsimulator"
+  XROS_DEPLOYMENT_TARGET=1.0
+)
+
+# ── Device ────────────────────────────────────────────────────────────────────
+echo "→ Archivando para visionOS Device (xros)..."
+xcodebuild archive "${XCFLAGS[@]}" \
+  -destination "generic/platform=visionOS" \
+  -archivePath "$ARCHIVES/device.xcarchive" \
+  -quiet
+echo "  ✓ Device"
+
+# ── XCFramework (device only) ─────────────────────────────────────────────────
+echo "→ Creando ViroKit.xcframework..."
+XCFW="$OUT_DIR/ViroKit.xcframework"
+rm -rf "$XCFW"
+
+DEV_FW="$ARCHIVES/device.xcarchive/Products/Library/Frameworks/ViroKit.framework"
+
+xcodebuild -create-xcframework \
+  -framework "$DEV_FW" \
+  -output "$XCFW"
+echo "  ✓ $XCFW"
+
+# ── Headers planos para HEADER_SEARCH_PATHS ───────────────────────────────────
+# VRORendererBridge.mm usa includes estilo "VRORenderer.h" (sin prefijo de framework),
+# así que necesitamos los headers en un directorio plano en HEADER_SEARCH_PATHS.
+echo "→ Extrayendo headers..."
+INCLUDE_DIR="$OUT_DIR/include"
+rm -rf "$INCLUDE_DIR"
+cp -r "$DEV_FW/Headers" "$INCLUDE_DIR"
+echo "  ✓ $INCLUDE_DIR ($(ls "$INCLUDE_DIR" | wc -l | tr -d ' ') headers)"
+
+# ── Limpieza ──────────────────────────────────────────────────────────────────
+rm -rf "$ARCHIVES"
+
+echo ""
+echo "=== Listo ==="
+echo "  XCFramework : $XCFW"
+echo "  Headers     : $INCLUDE_DIR"
+echo ""
+echo "Siguiente paso: rebuild viro (npm run build) y luego expo prebuild en showcase."


### PR DESCRIPTION
This pull request introduces major improvements to the ViroKit rendering engine, focusing on two main areas: (1) adding robust hover event hysteresis to improve user experience in OpenXR/visionOS controller interactions, and (2) introducing visionOS build system and platform support, including a new Metal-based driver and platform-specific configuration. These changes address issues with flickering hover states and unreliable click registration due to controller jitter, and lay the foundation for visionOS compatibility by excluding iOS-only code and providing a new Metal/CompositorServices backend.

**1. Input Controller Hover Hysteresis and Click Stickiness**  
*Significantly improves the reliability of hover and click events for OpenXR/visionOS controllers by introducing a 75ms hysteresis window. This absorbs short-term raycast jitter, preventing unwanted hover exits and ensuring clicks are routed to the intended node even if the pointer briefly jitters off target. This eliminates the need for repeated clicks to register an action and prevents flickering hover states.*  
- Added `HoverPending` state and `kHoverHysteresisMillis` to `VROInputControllerBase`, tracking pending hover transitions per input source. Hover exit/enter events are now deferred until the candidate node persists for the hysteresis window, and click events during this window are routed to the last hovered node. [[1]](diffhunk://#diff-b217ed6ab6cfea4124ca10b43473ec20ea56fa923757b68f86737f2514a4f820R342-R377) [[2]](diffhunk://#diff-80f17388bd900c7db637873a7b168d841a9b3fb8f7659befec97a49f99a2a1e4R95-R129) [[3]](diffhunk://#diff-80f17388bd900c7db637873a7b168d841a9b3fb8f7659befec97a49f99a2a1e4L116-R142) [[4]](diffhunk://#diff-80f17388bd900c7db637873a7b168d841a9b3fb8f7659befec97a49f99a2a1e4L133-R164) [[5]](diffhunk://#diff-80f17388bd900c7db637873a7b168d841a9b3fb8f7659befec97a49f99a2a1e4R519-R582)

**2. visionOS Platform and Build System Integration**  
*Enables ViroKit to build and run on visionOS by introducing platform-specific configuration, dependency management, and source exclusions for iOS-only features.*  
- Added `ios/Podfile.visionos` for visionOS CocoaPods integration, and updated `ViroKit.podspec` to declare visionOS deployment target and frameworks (Metal, MetalKit, CompositorServices, ARKit). [[1]](diffhunk://#diff-7a715aeb74a266640355f4786f0c16aaa931301f071a075977b7a901ea82cf18R1-R10) [[2]](diffhunk://#diff-ec93c478e4d3b44532c279a489609b4c70872c473f9753c13c754d24b1072f00R30-R36)
- Added `ios/ViroKit-visionOS.xcconfig` to exclude iOS-only source files from the visionOS build, set Metal as the rendering backend, and configure linker and header search paths for xros/xrsimulator.

**3. Metal/CompositorServices Backend for visionOS**  
*Introduces a new `VRODriverVisionOS` class implementing the rendering backend for visionOS, using Metal and CompositorServices, with stubs or minimal implementations for unsupported features.*  
- Added `VRODriverVisionOS.h` in the `VisionOS` subdirectory, providing a Metal-based driver with visionOS-specific overrides for rendering, resource management, and event handling.

These changes collectively improve input reliability on controller-based platforms and establish a robust foundation for future visionOS support in ViroKit.